### PR TITLE
Add example, add option to set resources, small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # terraform-aws-iam_instance_profile
-This is a module that makes it easy to create an iam_instance_profile. Built for 0.12
+This module creates an `iam_instance_profile` based on provided allowed actions and resources. The module is built for Terraform version 0.12
 
-Example Usage:
+## Examples
+See also [/examples/default] a complete working example.
+
+
+## Usages
 ```
 module "iam_instance_profile" {
     name = var.name
@@ -12,6 +16,8 @@ module "iam_instance_profile" {
     ]
 }
 
+##
 ```
-outputs:
-the name of the iam_instance_profile: `module.iam_instance_profile.name`
+
+## Outputs:
+The name of the iam_instance_profile: `module.iam_instance_profile.name`

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,0 +1,12 @@
+
+module "iam_instance_profile_default" {
+  source = "../../"
+}
+
+
+module "iam_instance_profile_optional_attributes" {
+  source  = "../../"
+  name    = "test"
+  actions = ["logs:*", "s3:*", "rds:*"]
+}
+

--- a/examples/default/providers.tf
+++ b/examples/default/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/examples/default/terraform.tfvars
+++ b/examples/default/terraform.tfvars
@@ -1,0 +1,1 @@
+region = "us-west-2"

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
 resource "aws_iam_role" "iam_role" {
   name = var.name
 
@@ -24,16 +28,14 @@ resource "aws_iam_instance_profile" "iam_instance_profile" {
 
 data "aws_iam_policy_document" "iam_policy_document" {
   statement {
-      effect = "Allow"
-      actions = var.actions
-      resources = [
-          "*"
-      ] 
+    effect = "Allow"
+    actions = var.actions
+    resources = var.resources
   }
 }
 
 resource "aws_iam_role_policy" "iam_role_policy" {
-  name   = var.name
-  role   = aws_iam_role.iam_role.name
+  name = var.name
+  role = aws_iam_role.iam_role.name
   policy = data.aws_iam_policy_document.iam_policy_document.json
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "name" {
-    value =  aws_iam_instance_profile.iam_instance_profile.name
+  description = "Name of create instance profile"
+  value       = aws_iam_instance_profile.iam_instance_profile.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,17 @@
 variable "name" {
-    default = null
-    type = string
+  description = "Name used for created resources."
+  default     = null
+  type        = string
 }
 
 variable "actions" {
-    default = ["logs:*"]
-    type = list(string)
+  description = "Actions allowed for this instance profile."
+  default     = ["logs:*"]
+  type        = list(string)
+}
+
+variable "resources" {
+  description = "Resources allowed to access by this instance profile."
+  default     = ["*"]
+  type        = list(string)
 }


### PR DESCRIPTION
I have made a few improvements

- Add an option to configure the resources
- Add an example in the examples dir. They will be shown in the registry
- Update some documentation
- The terraform-docs tool is not working yet on tf 0.12